### PR TITLE
fix: call reindex when add new address

### DIFF
--- a/lib/services/address_service.dart
+++ b/lib/services/address_service.dart
@@ -1,6 +1,8 @@
 import 'package:nft_collection/database/nft_collection_database.dart';
+import 'package:nft_collection/di/injector.dart';
 import 'package:nft_collection/models/address_collection.dart';
 import 'package:nft_collection/nft_collection.dart';
+import 'package:nft_collection/services/tokens_service.dart';
 
 class AddressService {
   final NftCollectionDatabase _database;
@@ -13,6 +15,7 @@ class AddressService {
             address: e,
             lastRefreshedTime: DateTime.fromMillisecondsSinceEpoch(0)))
         .toList());
+    await ncInjector<TokensService>().reindexAddresses(addresses);
   }
 
   Future<void> deleteAddresses(List<String> addresses) async {


### PR DESCRIPTION
**Description**

**Describe your changes**
[Sometimes, local cache of AU does not reload to get new indexing for view-only address](https://github.com/bitmark-inc/autonomy-apps/issues/3214)

- [ ] Added a function A to process data B
- [ ] Created new column C to store D state
- [ ] Refactor workflow E to improve performance because of F
